### PR TITLE
refactor: SDPD case_id

### DIFF
--- a/clean/ca/sacramento_pd.py
+++ b/clean/ca/sacramento_pd.py
@@ -94,7 +94,7 @@ class Site:
                     "title": url["title"],
                     "parent_page": html_location,
                     "asset_url": url["href"],
-                    "case_num": url["case_num"],
+                    "case_id": url["case_id"],
                     "name": url["name"],
                 }
             )
@@ -135,7 +135,7 @@ class Site:
                     "title": title_str,
                     "name": self._clean_text(link.text),
                     "href": href_str,
-                    "case_num": link.text.split(" from ")[-1],
+                    "case_id": link.text.split(" from ")[-1],
                 }
 
     def _extract_child_links(self, links: List[MetadataDict]) -> List[MetadataDict]:
@@ -155,7 +155,7 @@ class Site:
                 # Split URL and remove empty strings for trailing slash
                 url_split = [u for u in parsed_url.path.split("/") if u != ""]
                 if not self._is_asset(link["asset_url"]):
-                    filepath_stem = f"{link['case_num']}/{url_split[-1]}"
+                    filepath_stem = f"{link['case_id']}/{url_split[-1]}"  # type: ignore
                     try:
                         soup = self._download_and_parse(
                             link["asset_url"], filepath_stem
@@ -172,7 +172,7 @@ class Site:
                             "parent_page": link["parent_page"],
                             "asset_url": link["asset_url"],
                             "name": link["name"],
-                            "case_num": link["case_num"],
+                            "case_id": link["case_id"],
                         }
                     )
         return modified_links
@@ -197,7 +197,7 @@ class Site:
         for photo in photo_links:
             if str(photo["href"]).endswith("/"):
                 child_url = f'{ASSET_URL}{photo["href"]}'
-                child_filepath_stem = f"{link['case_num']}/{child_url.split('/')[-2]}"
+                child_filepath_stem = f"{link['case_id']}/{child_url.split('/')[-2]}"
                 child_soup = self._download_and_parse(child_url, child_filepath_stem)
                 more_photos = self._extract_photos(
                     child_soup, child_filepath_stem, link
@@ -215,7 +215,7 @@ class Site:
                         "parent_page": filepath_stem,
                         "asset_url": f'{ASSET_URL}{photo["href"]}',
                         "name": photo.get_text(),
-                        "case_num": link["case_num"],
+                        "case_id": link["case_id"],
                     }
                 )
 

--- a/clean/ca/sacramento_pd.py
+++ b/clean/ca/sacramento_pd.py
@@ -155,7 +155,7 @@ class Site:
                 # Split URL and remove empty strings for trailing slash
                 url_split = [u for u in parsed_url.path.split("/") if u != ""]
                 if not self._is_asset(link["asset_url"]):
-                    filepath_stem = f"{link['case_id']}/{url_split[-1]}"  # type: ignore
+                    filepath_stem = f"{link.get('case_id')}/{url_split[-1]}"
                     try:
                         soup = self._download_and_parse(
                             link["asset_url"], filepath_stem
@@ -172,7 +172,7 @@ class Site:
                             "parent_page": link["parent_page"],
                             "asset_url": link["asset_url"],
                             "name": link["name"],
-                            "case_id": link["case_id"],
+                            "case_id": link.get("case_id") or "",
                         }
                     )
         return modified_links
@@ -197,7 +197,9 @@ class Site:
         for photo in photo_links:
             if str(photo["href"]).endswith("/"):
                 child_url = f'{ASSET_URL}{photo["href"]}'
-                child_filepath_stem = f"{link['case_id']}/{child_url.split('/')[-2]}"
+                child_filepath_stem = (
+                    f"{link.get('case_id')}/{child_url.split('/')[-2]}"
+                )
                 child_soup = self._download_and_parse(child_url, child_filepath_stem)
                 more_photos = self._extract_photos(
                     child_soup, child_filepath_stem, link
@@ -215,7 +217,7 @@ class Site:
                         "parent_page": filepath_stem,
                         "asset_url": f'{ASSET_URL}{photo["href"]}',
                         "name": photo.get_text(),
-                        "case_id": link["case_id"],
+                        "case_id": link.get("case_id") or "",
                     }
                 )
 

--- a/clean/ca/san_diego_pd.py
+++ b/clean/ca/san_diego_pd.py
@@ -92,9 +92,7 @@ class Site:
             if filter and filter not in url:
                 continue
             # Get relative path to parent index_page directory
-            index_dir = (
-                asset["parent_page"].split(f"{self.agency_slug}/")[-1].rstrip(".html")
-            )
+            index_dir = asset["case_num"]
             asset_name = asset["name"].replace(" ", "_")
             download_path = Path(self.agency_slug, "assets", index_dir, asset_name)
             # Download the file to agency directory/assets/index_page_dir/case_name/file_name
@@ -125,6 +123,9 @@ class Site:
                                 "parent_page": str(html_file),
                                 "asset_url": link["href"].replace("\n", ""),
                                 "name": link.text.strip().replace("\n", ""),
+                                "case_num": str(html_file)
+                                .split(f"{self.agency_slug}/")[-1]
+                                .rstrip(".html"),
                             }
                             metadata.append(payload)
         # Store the metadata in a JSON file in the data directory

--- a/clean/ca/san_diego_pd.py
+++ b/clean/ca/san_diego_pd.py
@@ -92,7 +92,7 @@ class Site:
             if filter and filter not in url:
                 continue
             # Get relative path to parent index_page directory
-            index_dir = asset["case_num"]
+            index_dir = asset["case_id"]
             asset_name = asset["name"].replace(" ", "_")
             download_path = Path(self.agency_slug, "assets", index_dir, asset_name)
             # Download the file to agency directory/assets/index_page_dir/case_name/file_name
@@ -123,7 +123,7 @@ class Site:
                                 "parent_page": str(html_file),
                                 "asset_url": link["href"].replace("\n", ""),
                                 "name": link.text.strip().replace("\n", ""),
-                                "case_num": str(html_file)
+                                "case_id": str(html_file)
                                 .split(f"{self.agency_slug}/")[-1]
                                 .rstrip(".html"),
                             }

--- a/clean/utils.py
+++ b/clean/utils.py
@@ -31,7 +31,7 @@ CLEAN_LOG_DIR = CLEAN_OUTPUT_DIR / "logs"
 
 class MetadataDict(TypedDict):
     asset_url: str
-    case_num: NotRequired[str]
+    case_id: NotRequired[str]
     name: str
     parent_page: str
     title: Optional[str]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -169,7 +169,7 @@ The file should be saved to the cache folder's `exports/` directory. In the case
 The metadata file should contain an array of one or more objects with the below attributes:
 
 - **required** `asset_url`: The URL where a file can be downloaded.
-- `case_number`: A string to associate the asset with a specific incident
+- `case_id`: A string to associate the asset with a specific incident
 - `name`: The base name of the file, minus prior path components.
 - `parent_page`: The local file path in cache to the HTML page containing the `asset_url`.
 - `title`: (optional) If available, this will typically be a human-friendly title for the file.
@@ -191,7 +191,7 @@ Below is an example from `ca_san_diego_pd.json` metadata JSON.
         "name": "November 21, 2022 IA #2022-013_Audio_Interview Complainant_Redacted_KM.wav",
         "parent_page": "/ca_san_diego_pd/sb16-sb1421-ab748/11-21-2022_IA_2022-013.html",
         "title": "11-21-2022 IA 2022-013",
-        "case_num": "abc123",
+        "case_id": "abc123",
         "details": {
             "filesize": 9999,
             "date_modified": "2024-01-01T19:20:00+1:00"


### PR DESCRIPTION
## Description

1. Take existing case information being used for the `scrape` method to organize assets and create a new metadata key/value field `case_num`
2. Use `case_num` to create the file tree structure for saving assets

### Goal

Facilitate `clean-prefect` scrapes while removing complexity from `clean-scraper`

## How to review

- Does `case_num` for SDPD look correct? (Note: other agency case_nums may look different depending upon the agency).

```sh
> python -m clean.cli scrape-meta ca_san_diego_pd
sb16-sb1421-ab748_page=4/04-30-2015_3200_Hancock_Stree
sb16-sb1421-ab748_page=4/09-28-2015_1100_West_San_Ysidro_Boulevard
sb16-sb1421-ab748_page=4/04-01-2014_IA_2014-185
```