### PR TITLE
fix: pytest vcr marker warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    vcr: mark a test as using VCR


### PR DESCRIPTION
## Description

Adds `pytest.ini` to reduce console warnings in favor of relevant errors. Follow-up to #20 

## How to review

- Run tests (see `docs/mainters.md`)
- Confirm no warning messages about VCR marker appear