### PR TITLE
Patch list_agencies bug #85

### DIFF
--- a/clean/utils.py
+++ b/clean/utils.py
@@ -163,20 +163,22 @@ def get_all_scrapers():
     abbrevs = [state.abbr.lower() for state in us.states.STATES]
     state_folders = [p for p in folders if p.stem in abbrevs]
     scrapers = {}
+    unwanted_files = [
+        ".mypy_cache",
+        "config",
+    ]
+
     for state_folder in state_folders:
         state = state_folder.stem
         for mod_path in state_folder.iterdir():
-            if not mod_path.stem.startswith("__"):
-                if mod_path.stem not in [".mypy_cache", "config"]:
-                    agency_mod = importlib.import_module(
-                        f"clean.{state}.{mod_path.stem}"
-                    )
-                    scrapers.setdefault(state, []).append(
-                        {
-                            "slug": f"{state}_{mod_path.stem}",
-                            "agency": agency_mod.Site.name,
-                        }
-                    )
+            if not (mod_path.stem.startswith("__") or mod_path.stem in unwanted_files):
+                agency_mod = importlib.import_module(f"clean.{state}.{mod_path.stem}")
+                scrapers.setdefault(state, []).append(
+                    {
+                        "slug": f"{state}_{mod_path.stem}",
+                        "agency": agency_mod.Site.name,
+                    }
+                )
     return scrapers
 
 

--- a/clean/utils.py
+++ b/clean/utils.py
@@ -167,10 +167,16 @@ def get_all_scrapers():
         state = state_folder.stem
         for mod_path in state_folder.iterdir():
             if not mod_path.stem.startswith("__"):
-                agency_mod = importlib.import_module(f"clean.{state}.{mod_path.stem}")
-                scrapers.setdefault(state, []).append(
-                    {"slug": f"{state}_{mod_path.stem}", "agency": agency_mod.Site.name}
-                )
+                if mod_path.stem not in [".mypy_cache", "config"]:
+                    agency_mod = importlib.import_module(
+                        f"clean.{state}.{mod_path.stem}"
+                    )
+                    scrapers.setdefault(state, []).append(
+                        {
+                            "slug": f"{state}_{mod_path.stem}",
+                            "agency": agency_mod.Site.name,
+                        }
+                    )
     return scrapers
 
 


### PR DESCRIPTION
## Description

Per #85 , `list_agencies` relies on `utils.get_all_scrapers`, which breaks during routine maintenance because of `.mypy_cache`. It also breaks because of the `config` directory being brought in with the schema introduced in #51  .

### Summary of Changes

- This excludes anything in `.mypy_cache` or `config` directories.

### Related Issues

- This should close out #85 . It's possible files to ignore may need to be added as work progresses.

## How to Review

- This seems pretty simple to me. There may be other ways to handle this.

## Notes

- ... pretty simple